### PR TITLE
Fix bug in `decode` function

### DIFF
--- a/src/multipart.lua
+++ b/src/multipart.lua
@@ -38,7 +38,7 @@ local function decode(body, boundary)
   local part_index = 1
   local part_name, part_value
 
-  for line in body:gmatch("[^\r\n]+") do
+  for line in body:gmatch("([%s%S]+?)\r\n") do
     if pl_string.startswith(line, "--"..boundary) then
       if part_name ~= nil then
         result.data[part_index] = {


### PR DESCRIPTION
Currently regex works not always correctly in decode function.
For example if body = `a\r\r\n\n b`, then two groups will be
generated `a` and ` b`, instead of `a\r` and `\n b`.