### PR TITLE
fix(parser): properly parse when there is no header whitespace

### DIFF
--- a/spec/multipart_spec.lua
+++ b/spec/multipart_spec.lua
@@ -152,6 +152,73 @@ hello
     assert.are.same("... contents of file1.txt ...\r\nhello", all["files"])
   end)
 
+  it("should decode a multipart body without header whitespace", function() 
+
+    local content_type = "multipart/form-data;boundary=AaB03x"
+    local body = [[
+--AaB03x
+Content-Disposition:form-data;name="submit-name"
+
+Larry
+--AaB03x
+Content-Disposition:form-data;name="files";filename="file1.txt"
+Content-Type:text/plain
+
+... contents of file1.txt ...
+hello
+--AaB03x--]]
+
+    local res = Multipart(body, content_type)
+    assert.truthy(res)
+
+    local internal_data = res._data
+
+    -- Check internals
+    local index = internal_data.indexes["submit-name"]
+    assert.truthy(index)
+    assert.are.same(1, index)
+    assert.truthy(internal_data.data[index])
+    assert.truthy(internal_data.data[index].name)
+    assert.are.same("submit-name", internal_data.data[index].name)
+    assert.truthy(internal_data.data[index].headers)
+    assert.are.same({"Content-Disposition:form-data;name=\"submit-name\""}, internal_data.data[index].headers)
+    assert.are.same(1, table_size(internal_data.data[index].headers))
+    assert.truthy(internal_data.data[index].value)
+    assert.are.same("Larry", internal_data.data[index].value)
+
+    index = internal_data.indexes["files"]
+    assert.truthy(index)
+    assert.are.same(2, index)
+    assert.truthy(internal_data.data[index])
+    assert.truthy(internal_data.data[index].name)
+    assert.are.same("files", internal_data.data[index].name)
+    assert.truthy(internal_data.data[index].headers)
+    assert.are.same({"Content-Disposition:form-data;name=\"files\";filename=\"file1.txt\"", "Content-Type:text/plain"}, internal_data.data[index].headers)
+    assert.are.same(2, table_size(internal_data.data[index].headers))
+    assert.truthy(internal_data.data[index].value)
+    assert.are.same("... contents of file1.txt ...\r\nhello", internal_data.data[index].value)
+
+    -- Check interface
+
+    local param = res:get("submit-name")
+    assert.truthy(param)
+    assert.are.same("submit-name", param.name)
+    assert.are.same({"Content-Disposition:form-data;name=\"submit-name\""}, param.headers)
+    assert.are.same("Larry", param.value)
+
+    param = res:get("files")
+    assert.truthy(param)
+    assert.are.same("files", param.name)
+    assert.are.same({"Content-Disposition:form-data;name=\"files\";filename=\"file1.txt\"", "Content-Type:text/plain"}, param.headers)
+    assert.are.same("... contents of file1.txt ...\r\nhello", param.value)
+
+    local all = res:get_all()
+
+    assert.are.same(2, table_size(all))
+    assert.are.same("Larry", all["submit-name"])
+    assert.are.same("... contents of file1.txt ...\r\nhello", all["files"])
+  end)
+
   it("should encode a multipart body", function() 
     local content_type = "multipart/form-data; boundary=AaB03x"
     local body = [[

--- a/src/multipart.lua
+++ b/src/multipart.lua
@@ -106,7 +106,7 @@ function MultipartData.new(data, content_type)
   local instance = {}
   setmetatable(instance, MultipartData)
   if content_type then
-    instance._boundary = string.match(content_type, ";%s+boundary=(%S+)")
+    instance._boundary = string.match(content_type, ";%s*boundary=(%S+)")
   end
   instance._data = decode(data or "", instance._boundary)
   return instance


### PR DESCRIPTION
- Updates the pattern to match 0 or more whitespace
- Adds a testcase
- Fixes #9 
