### PR TITLE
perf(parser) refactor part_value to use temp a table

### DIFF
--- a/multipart-0.5.1-1.rockspec
+++ b/multipart-0.5.1-1.rockspec
@@ -1,8 +1,8 @@
 package = "multipart"
-version = "0.5-1"
+version = "0.5.1-1"
 source = {
   url = "git://github.com/Mashape/lua-multipart",
-  tag = "0.5-1"
+  tag = "0.5.1-1"
 }
 description = {
   summary = "A simple HTTP multipart encoder/decoder for Lua",

--- a/src/multipart.lua
+++ b/src/multipart.lua
@@ -36,7 +36,9 @@ local function decode(body, boundary)
 
   local part_headers = {}
   local part_index = 1
-  local part_name, part_value
+  local part_name, part_value, part_value_ct
+  part_value = {}
+  part_value_ct = 0
 
   for line in body:gmatch("[^\r\n]+") do
     if pl_string.startswith(line, "--"..boundary) then
@@ -44,14 +46,15 @@ local function decode(body, boundary)
         result.data[part_index] = {
           name = part_name,
           headers = part_headers,
-          value = part_value
+          value = table.concat(part_value, "\r\n")
         }
 
         result.indexes[part_name] = part_index
 
         -- Reset fields for the next part
         part_headers = {}
-        part_value = nil
+        part_value = {}
+        part_value_ct = 0
         part_name = nil
         part_index = part_index + 1
       end
@@ -73,7 +76,8 @@ local function decode(body, boundary)
         table.insert(part_headers, line)
       else
         -- The value part begins
-        part_value = (part_value and part_value.."\r\n" or "")..line
+        part_value_ct = part_value_ct + 1
+        part_value[part_value_ct] = line
       end
     end
   end


### PR DESCRIPTION
Reduce string operation pressure significantly by treating each part
value as a table of elements and concatenating them together in a single
operation.