### PR TITLE
fix handling of the part body content starting with "\r\n"

### DIFF
--- a/multipart-0.5.4-1.rockspec
+++ b/multipart-0.5.4-1.rockspec
@@ -1,8 +1,8 @@
 package = "multipart"
-version = "0.5.3-1"
+version = "0.5.4-1"
 source  = {
   url = "git://github.com/Kong/lua-multipart",
-  tag = "0.5.3-1",
+  tag = "0.5.4-1",
 }
 description = {
   summary  = "A simple HTTP multipart encoder/decoder for Lua",

--- a/src/multipart.lua
+++ b/src/multipart.lua
@@ -118,7 +118,8 @@ local function decode(body, boundary)
         end
 
       else
-        if not processing_part_value and line:sub(1, 19):lower() == "content-disposition" then --Beginning of part
+        --Beginning of part
+        if not processing_part_value and line:sub(1, 19):lower() == "content-disposition" then
           -- Extract part_name
           for v in line:gmatch("[^;]+") do
             if not is_header(v) then -- If it's not content disposition part
@@ -132,8 +133,18 @@ local function decode(body, boundary)
 
           insert(part_headers, line)
 
+          if sub(body, s, s + 3) == "\r\n\r\n" then
+            processing_part_value = true
+            position = s + 4
+          end
+
         elseif not processing_part_value and is_header(line) then
           insert(part_headers, line)
+
+          if sub(body, s, s + 3) == "\r\n\r\n" then
+            processing_part_value = true
+            position = s + 4
+          end
 
         else
           processing_part_value = true
@@ -185,6 +196,10 @@ local function encode(t, boundary)
 
       i = i + 3
     end
+  end
+
+  if i == 0 then
+    return ""
   end
 
   result[i + 1] = "--"


### PR DESCRIPTION
Yet another PR to fix one remaining bug with parsing in this library. 

- Fix issue when new lines were not considered to be part of the body when thet occured just after the headers
- Small fix on encoding when there were no parts to be encoded, we did sent the ending boundary (no we don't anymore and instead we send empty body)