### PR TITLE
Added support for multiple filenames with same part name

### DIFF
--- a/multipart-0.5.7-1.rockspec
+++ b/multipart-0.5.7-1.rockspec
@@ -1,8 +1,8 @@
 package = "multipart"
-version = "0.5.6-1"
+version = "0.5.7-1"
 source  = {
   url = "git://github.com/Kong/lua-multipart",
-  tag = "0.5.6-1",
+  tag = "0.5.7-1",
 }
 description = {
   summary  = "A simple HTTP multipart encoder/decoder for Lua",

--- a/spec/multipart_spec.lua
+++ b/spec/multipart_spec.lua
@@ -128,6 +128,7 @@ planetCRLFearth
     assert.truthy(internal_data.data[index])
     assert.truthy(internal_data.data[index].name)
     assert.are.same("files", internal_data.data[index].name)
+    assert.are.same("file1.txt", internal_data.data[index].filename)
     assert.truthy(internal_data.data[index].headers)
     assert.are.same({"Content-Disposition: form-data; name=\"files\"; filename=\"file1.txt\"", "Content-Type: text/plain"}, internal_data.data[index].headers)
     assert.are.same(2, table_size(internal_data.data[index].headers))
@@ -145,6 +146,7 @@ planetCRLFearth
     param = res:get("files", "file1.txt")
     assert.truthy(param)
     assert.are.same("files", param.name)
+    assert.are.same("file1.txt", param.filename)
     assert.are.same({"Content-Disposition: form-data; name=\"files\"; filename=\"file1.txt\"", "Content-Type: text/plain"}, param.headers)
     assert.are.same("... contents of file1.txt ...\nhello\n\nplanet\r\nearth", param.value)
 
@@ -190,6 +192,7 @@ hello
     assert.truthy(internal_data.data[index])
     assert.truthy(internal_data.data[index].name)
     assert.are.same("files", internal_data.data[index].name)
+    assert.are.same("file1.txt", internal_data.data[index].filename)
     assert.truthy(internal_data.data[index].headers)
     assert.are.same({"Content-Disposition: form-data; name=\"files\"; filename=\"file1.txt\"", "Content-Type: text/plain"}, internal_data.data[index].headers)
     assert.are.same(2, table_size(internal_data.data[index].headers))
@@ -207,6 +210,7 @@ hello
     param = res:get("files", "file1.txt")
     assert.truthy(param)
     assert.are.same("files", param.name)
+    assert.are.same("file1.txt", param.filename)
     assert.are.same({"Content-Disposition: form-data; name=\"files\"; filename=\"file1.txt\"", "Content-Type: text/plain"}, param.headers)
     assert.are.same("... contents of file1.txt ...\nhello", param.value)
 
@@ -362,6 +366,7 @@ hello
     assert.truthy(internal_data.data[index])
     assert.truthy(internal_data.data[index].name)
     assert.are.same("files", internal_data.data[index].name)
+    assert.are.same("file1.txt", internal_data.data[index].filename)
     assert.truthy(internal_data.data[index].headers)
     assert.are.same({"Content-Disposition:form-data;name=\"files\";filename=\"file1.txt\"", "Content-Type:text/plain"}, internal_data.data[index].headers)
     assert.are.same(2, table_size(internal_data.data[index].headers))
@@ -379,6 +384,7 @@ hello
     param = res:get("files", "file1.txt")
     assert.truthy(param)
     assert.are.same("files", param.name)
+    assert.are.same("file1.txt", param.filename)
     assert.are.same({"Content-Disposition:form-data;name=\"files\";filename=\"file1.txt\"", "Content-Type:text/plain"}, param.headers)
     assert.are.same("... contents of file1.txt ...\nhello", param.value)
 

--- a/spec/multipart_spec.lua
+++ b/spec/multipart_spec.lua
@@ -150,10 +150,10 @@ planetCRLFearth
 
   end)
 
-  it("should decode a multipart/related body", function()
+  it("should decode a multipart body", function()
 
-    local content_type = "multipart/related; boundary=AaB03x"
-    local body = ([[
+    local content_type = "multipart/form-data; boundary=AaB03x"
+    local body = [[
 --AaB03x
 Content-Disposition: form-data; name="submit-name"
 
@@ -164,9 +164,7 @@ Content-Type: text/plain
 
 ... contents of file1.txt ...
 hello
-
-planetCRLFearth
---AaB03x--]]):gsub("CRLF", "\r\n")
+--AaB03x--]]
 
     local res = Multipart(body, content_type)
     assert.truthy(res)
@@ -196,7 +194,7 @@ planetCRLFearth
     assert.are.same({"Content-Disposition: form-data; name=\"files\"; filename=\"file1.txt\"", "Content-Type: text/plain"}, internal_data.data[index].headers)
     assert.are.same(2, table_size(internal_data.data[index].headers))
     assert.truthy(internal_data.data[index].value)
-    assert.are.same("... contents of file1.txt ...\nhello\n\nplanet\r\nearth", internal_data.data[index].value)
+    assert.are.same("... contents of file1.txt ...\nhello", internal_data.data[index].value)
 
     -- Check interface
 
@@ -210,8 +208,13 @@ planetCRLFearth
     assert.truthy(param)
     assert.are.same("files", param.name)
     assert.are.same({"Content-Disposition: form-data; name=\"files\"; filename=\"file1.txt\"", "Content-Type: text/plain"}, param.headers)
-    assert.are.same("... contents of file1.txt ...\nhello\n\nplanet\r\nearth", param.value)
+    assert.are.same("... contents of file1.txt ...\nhello", param.value)
 
+    local all = res:get_all()
+
+    assert.are.same(2, table_size(all))
+    assert.are.same("Larry", all["submit-name"])
+    assert.are.same("... contents of file1.txt ...\nhello", all["files"])
   end)
 
   it("should decode a multipart body with multiple file parts and missing and repeating filename", function()
@@ -667,7 +670,7 @@ hello
     local data = res:tostring()
     assert.are.same(#new_body, #data)
   end)
-  
+
   it("should encode a multipart body file with set param used", function()
     local content_type = "multipart/form-data; boundary=AaB03x"
     local body = [[

--- a/spec/multipart_spec.lua
+++ b/spec/multipart_spec.lua
@@ -110,9 +110,11 @@ planetCRLFearth
     local internal_data = res._data
 
     -- Check internals
-    local index = internal_data.indexes["submit-name"]
+    local indexes = internal_data.indexes["submit-name"]
+    assert.truthy(indexes)
+    assert.are.same({1}, indexes)
+    local index = indexes[1]
     assert.truthy(index)
-    assert.are.same(1, index)
     assert.truthy(internal_data.data[index])
     assert.truthy(internal_data.data[index].name)
     assert.are.same("submit-name", internal_data.data[index].name)
@@ -122,7 +124,9 @@ planetCRLFearth
     assert.truthy(internal_data.data[index].value)
     assert.are.same("Larry", internal_data.data[index].value)
 
-    index = internal_data.indexes["files"]
+    indexes = internal_data.indexes["files"]
+    assert.truthy(indexes)
+    index = indexes[1]
     assert.truthy(index)
     assert.are.same(2, index)
     assert.truthy(internal_data.data[index])
@@ -172,9 +176,11 @@ hello
     local internal_data = res._data
 
     -- Check internals
-    local index = internal_data.indexes["submit-name"]
+    local indexes = internal_data.indexes["submit-name"]
+    assert.truthy(indexes)
+    assert.are.same({1}, indexes)
+    local index = indexes[1]
     assert.truthy(index)
-    assert.are.same(1, index)
     assert.truthy(internal_data.data[index])
     assert.truthy(internal_data.data[index].name)
     assert.are.same("submit-name", internal_data.data[index].name)
@@ -184,7 +190,9 @@ hello
     assert.truthy(internal_data.data[index].value)
     assert.are.same("Larry", internal_data.data[index].value)
 
-    index = internal_data.indexes["files"]
+    indexes = internal_data.indexes["files"]
+    assert.truthy(indexes)
+    index = indexes[1]
     assert.truthy(index)
     assert.are.same(2, index)
     assert.truthy(internal_data.data[index])
@@ -249,9 +257,11 @@ Content-Type: text/plain
     local internal_data = res._data
 
     -- Check internals
-    local index = internal_data.indexes["files"]
+    local indexes = internal_data.indexes["files"]
+    assert.truthy(indexes)
+    assert.are.same({1, 2, 3, 4}, indexes)
+    local index = indexes[1]
     assert.truthy(index)
-    assert.are.same(1, index)
     assert.truthy(internal_data.data[index])
     assert.truthy(internal_data.data[index].name)
     assert.are.same("files", internal_data.data[index].name)
@@ -261,9 +271,7 @@ Content-Type: text/plain
     assert.truthy(internal_data.data[index].value)
     assert.are.same("... contents of file1.txt ...", internal_data.data[index].value)
 
-    index = internal_data.indexes["files_part_number_2"]
-    assert.truthy(index)
-    assert.are.same(2, index)
+    index = indexes[2]
     assert.truthy(internal_data.data[index])
     assert.truthy(internal_data.data[index].name)
     assert.are.same("files", internal_data.data[index].name)
@@ -273,7 +281,7 @@ Content-Type: text/plain
     assert.truthy(internal_data.data[index].value)
     assert.are.same("... contents of file2.txt ...", internal_data.data[index].value)
 
-    index = internal_data.indexes["files_part_number_3"]
+    index = indexes[3]
     assert.truthy(index)
     assert.are.same(3, index)
     assert.truthy(internal_data.data[index])
@@ -285,7 +293,7 @@ Content-Type: text/plain
     assert.truthy(internal_data.data[index].value)
     assert.are.same("... contents of file3.txt ...", internal_data.data[index].value)
 
-    index = internal_data.indexes["files_part_number_4"]
+    index = indexes[4]
     assert.truthy(index)
     assert.are.same(4, index)
     assert.truthy(internal_data.data[index])
@@ -306,11 +314,29 @@ Content-Type: text/plain
 
     local all = res:get_all()
 
-    assert.are.same(4, table_size(all))
+    assert.are.same(1, table_size(all))
     assert.are.same("... contents of file1.txt ...", all["files"])
-    assert.are.same("... contents of file2.txt ...", all["files_part_number_2"])
-    assert.are.same("... contents of file3.txt ...", all["files_part_number_3"])
-    assert.are.same("... contents of file4.txt ...", all["files_part_number_4"])
+
+    local as_array = res:get_as_array("files")
+    assert.truthy(as_array)
+    assert.are.same({
+      "... contents of file1.txt ...",
+      "... contents of file2.txt ...",
+      "... contents of file3.txt ...",
+      "... contents of file4.txt ...",
+    }, as_array)
+
+    local as_array_all = res:get_all_with_arrays()
+    assert.truthy(as_array_all)
+    as_array = as_array_all["files"]
+    assert.truthy(as_array)
+    assert.are.same({
+      "... contents of file1.txt ...",
+      "... contents of file2.txt ...",
+      "... contents of file3.txt ...",
+      "... contents of file4.txt ...",
+    }, as_array)
+
   end)
 
   it("should decode invalid empty multipart body", function()
@@ -336,9 +362,11 @@ Content-Disposition: form-data; name="submit-name"]]
     local internal_data = res._data
 
     -- Check internals
-    local index = internal_data.indexes["submit-name"]
+    local indexes = internal_data.indexes["submit-name"]
+    assert.truthy(indexes)
+    assert.are.same({1}, indexes)
+    local index = indexes[1]
     assert.truthy(index)
-    assert.are.same(1, index)
     assert.truthy(internal_data.data[index])
     assert.truthy(internal_data.data[index].name)
     assert.are.same("submit-name", internal_data.data[index].name)
@@ -375,9 +403,11 @@ Content-Disposition: form-data; name="submit-name"]]
 
     local internal_data = res._data
 
-    local index = internal_data.indexes["submit-name"]
+    local indexes = internal_data.indexes["submit-name"]
+    assert.truthy(indexes)
+    assert.are.same({1}, indexes)
+    local index = indexes[1]
     assert.truthy(index)
-    assert.are.same(1, index)
     assert.truthy(internal_data.data[index])
     assert.truthy(internal_data.data[index].name)
     assert.are.same("submit-name", internal_data.data[index].name)
@@ -402,9 +432,11 @@ Content-Disposition: form-data; name="submit-name"]]
 
     local internal_data = res._data
 
-    local index = internal_data.indexes["submit-name"]
+    local indexes = internal_data.indexes["submit-name"]
+    assert.truthy(indexes)
+    assert.are.same({1}, indexes)
+    local index = indexes[1]
     assert.truthy(index)
-    assert.are.same(1, index)
     assert.truthy(internal_data.data[index])
     assert.truthy(internal_data.data[index].name)
     assert.are.same("submit-name", internal_data.data[index].name)
@@ -440,9 +472,11 @@ hello
     local internal_data = res._data
 
     -- Check internals
-    local index = internal_data.indexes["submit-name"]
+    local indexes = internal_data.indexes["submit-name"]
+    assert.truthy(indexes)
+    assert.are.same({1}, indexes)
+    local index = indexes[1]
     assert.truthy(index)
-    assert.are.same(1, index)
     assert.truthy(internal_data.data[index])
     assert.truthy(internal_data.data[index].name)
     assert.are.same("submit-name", internal_data.data[index].name)
@@ -452,9 +486,11 @@ hello
     assert.truthy(internal_data.data[index].value)
     assert.are.same("Larry", internal_data.data[index].value)
 
-    index = internal_data.indexes["files"]
+    indexes = internal_data.indexes["files"]
+    assert.truthy(indexes)
+    assert.are.same({2}, indexes)
+    index = indexes[1]
     assert.truthy(index)
-    assert.are.same(2, index)
     assert.truthy(internal_data.data[index])
     assert.truthy(internal_data.data[index].name)
     assert.are.same("files", internal_data.data[index].name)
@@ -738,7 +774,7 @@ Content-Type: text/plain
     res:set_simple("hello2", "world2 :)")
 
     local data = res:tostring()
-    assert.are.same(#new_body, #data)
+    assert.are.same(new_body, data)
   end)
 
   it("should encode a multipart body file with set param used and same filename and skipped filename", function()
@@ -813,7 +849,7 @@ Content-Type: text/plain
     res:set_simple("hello2", "world2 :)")
 
     local data = res:tostring()
-    assert.are.same(#new_body, #data)
+    assert.are.same(new_body, data)
   end)
 
 end)
@@ -856,6 +892,7 @@ hello
   local data = res:tostring()
   assert.are.same(new_body, data)
 end)
+
 it("set a file example", function()
     local content_type = "multipart/related; boundary=0f755aa8"
     local body = ""

--- a/spec/multipart_spec.lua
+++ b/spec/multipart_spec.lua
@@ -1,4 +1,4 @@
-local Multipart = require "fs-multipart"
+local Multipart = require "multipart"
 
 local function table_size(t)
   local res = 0

--- a/spec/multipart_spec.lua
+++ b/spec/multipart_spec.lua
@@ -296,6 +296,21 @@ Content-Type: text/plain
     assert.are.same(2, table_size(internal_data.data[index].headers))
     assert.truthy(internal_data.data[index].value)
     assert.are.same("... contents of file4.txt ...", internal_data.data[index].value)
+
+    -- Check interface
+    local param = res:get("files")
+    assert.truthy(param)
+    assert.are.same("files", param.name)
+    assert.are.same({"Content-Disposition: form-data; name=\"files\"; filename=\"file1.txt\"", "Content-Type: text/plain"}, param.headers)
+    assert.are.same("... contents of file1.txt ...", param.value)
+
+    local all = res:get_all()
+
+    assert.are.same(4, table_size(all))
+    assert.are.same("... contents of file1.txt ...", all["files"])
+    assert.are.same("... contents of file2.txt ...", all["files_part_number_2"])
+    assert.are.same("... contents of file3.txt ...", all["files_part_number_3"])
+    assert.are.same("... contents of file4.txt ...", all["files_part_number_4"])
   end)
 
   it("should decode invalid empty multipart body", function()

--- a/src/multipart.lua
+++ b/src/multipart.lua
@@ -43,18 +43,6 @@ local function table_size(t)
   return res
 end
 
--- Get updated name with optional counter
---
--- @param {string}  part_name Name of part
--- @param {string}  count Optional counter
--- @return {string} New part name
-local function get_part_name(part_name, count)
-    local new_name = part_name
-    if count ~= nil and type(count) == "number" and count > 1 then
-        new_name = new_name .. "_part_number_" .. count
-    end
-    return new_name
-end
 
 -- Create a table representation of multipart/data body
 --
@@ -76,8 +64,6 @@ local function decode(body, boundary)
   local part_headers  = {}
   local part_value    = {}
   local part_value_ct = 0
-
-  local part_counter = {}
 
   local end_boundary_length   = boundary and #boundary + 2
   local processing_part_value = false
@@ -130,12 +116,10 @@ local function decode(body, boundary)
             value   = concat(part_value)
           }
 
-          if part_counter[part_name] == nil then
-              part_counter[part_name] = 0
+          if result.indexes[part_name] == nil then
+            result.indexes[part_name] = {}
           end
-          part_counter[part_name] = part_counter[part_name] + 1
-
-          result.indexes[get_part_name(part_name, part_counter[part_name])] = part_index
+          table.insert(result.indexes[part_name], part_index)
 
           -- Reset fields for the next part
           part_headers  = {}
@@ -197,7 +181,7 @@ local function decode(body, boundary)
       headers = part_headers,
       value   = concat(part_value)
     }
-    result.indexes[get_part_name(part_name, part_counter[part_name])] = part_index
+    result.indexes[part_name] = {part_index}
   end
 
   return result
@@ -275,7 +259,8 @@ end
 
 
 function MultipartData:get(name)
-  return self._data.data[self._data.indexes[name]]
+  -- Get first index for part
+  return self._data.data[self._data.indexes[name][1]]
 end
 
 
@@ -283,11 +268,33 @@ function MultipartData:get_all()
   local result = {}
 
   for k, v in pairs(self._data.indexes) do
-    result[k] = self._data.data[v].value
+    -- Get first index for part
+    result[k] = self._data.data[v[1]].value
   end
 
   return result
 end
+
+
+function MultipartData:get_as_array(name)
+  local vals = {}
+  for _, index in ipairs(self._data.indexes[name]) do
+    table.insert(vals, self._data.data[index].value)
+  end
+  return vals
+end
+
+
+function MultipartData:get_all_with_arrays()
+  local result = {}
+
+  for k, v in pairs(self._data.indexes) do
+    result[k] = self:get_as_array(k)
+  end
+
+  return result
+end
+
 
 
 function MultipartData:set_simple(name, value, filename, content_type)
@@ -303,15 +310,25 @@ function MultipartData:set_simple(name, value, filename, content_type)
     end
     headers = concat(headers)
     if self._data.indexes[name] then
-      self._data.data[self._data.indexes[name]] = {
+      self._data.data[self._data.indexes[name][1]] = {
         name = name,
         value = value,
         headers = {headers}
       }
 
     else
-      local part_index = table_size(self._data.indexes) + 1
-      self._data.indexes[name] = part_index
+      -- Find maxium index
+      local max_index = 0
+      for k, indexes in pairs(self._data.indexes) do
+        for i, index in ipairs(indexes) do
+          if index > max_index then
+            max_index = index
+          end
+        end
+      end
+      -- Assign data to new index
+      local part_index = max_index + 1
+      self._data.indexes[name] = {part_index}
       self._data.data[part_index] = {
         name    = name,
         value   = value,
@@ -322,16 +339,28 @@ end
 
 
 function MultipartData:delete(name)
-  local index = self._data.indexes[name]
+  -- If part name repeats, then delete all occurances.
+  local indexes = self._data.indexes[name]
 
-  if index then
-     remove(self._data.data, index)
-     self._data.indexes[name] = nil
+  if indexes ~= nil then
+    for i, index in ipairs(indexes) do
+      remove(self._data.data, index)
+    end
+    self._data.indexes[name] = nil
 
     -- need to recount index
-    for key, value in pairs(self._data.indexes) do
-      if value > index then
-        self._data.indexes[key] = value - 1
+    -- Deleted indexes can be anywhere,
+    -- including between values of indexes for single part name.
+    -- For every index, need to count how many deleted indexes are bellow it
+    for key, index_vals in pairs(self._data.indexes) do
+      for i, val in ipairs(index_vals) do
+        local num_deleted = 0
+        for _, del_index in ipairs(indexes) do
+          if val > del_index then
+            num_deleted = num_deleted + 1
+          end
+        end
+        self._data.indexes[key][i] = val - num_deleted
       end
     end
   end

--- a/src/multipart.lua
+++ b/src/multipart.lua
@@ -132,7 +132,7 @@ local function decode(body, boundary)
 
           if part_counter[part_name] == nil then
               part_counter[part_name] = 0
-          end 
+          end
           part_counter[part_name] = part_counter[part_name] + 1
 
           result.indexes[get_part_name(part_name, part_counter[part_name])] = part_index

--- a/src/multipart.lua
+++ b/src/multipart.lua
@@ -43,7 +43,6 @@ local function table_size(t)
   return res
 end
 
-
 -- Create a table representation of multipart/data body
 --
 -- @param {string} body The multipart/data string body
@@ -294,7 +293,6 @@ function MultipartData:get_all_with_arrays()
 
   return result
 end
-
 
 
 function MultipartData:set_simple(name, value, filename, content_type)

--- a/src/multipart.lua
+++ b/src/multipart.lua
@@ -43,6 +43,15 @@ local function table_size(t)
   return res
 end
 
+local function get_part_key(part_name, part_filename)
+    assert(part_name ~= nil)
+    local part_key = part_name
+    if part_filename ~= nil then
+        part_key = part_key .. "_" .. part_filename
+    end
+    return part_key
+end
+
 -- Create a table representation of multipart/data body
 --
 -- @param {string} body The multipart/data string body
@@ -59,6 +68,7 @@ local function decode(body, boundary)
   end
 
   local part_name
+  local part_filename
   local part_index    = 1
   local part_headers  = {}
   local part_value    = {}
@@ -110,31 +120,41 @@ local function decode(body, boundary)
           end
 
           result.data[part_index] = {
-            name    = part_name,
-            headers = part_headers,
-            value   = concat(part_value)
+            name        = part_name,
+            filename    = part_filename,
+            headers     = part_headers,
+            value       = concat(part_value)
           }
 
-          result.indexes[part_name] = part_index
+          local part_key = get_part_key(part_name, part_filename)
+          result.indexes[part_key] = part_index
 
           -- Reset fields for the next part
           part_headers  = {}
           part_value    = {}
           part_value_ct = 0
           part_name     = nil
+          file_name     = nil
           part_index    = part_index + 1
         end
 
       else
         --Beginning of part
         if not processing_part_value and line:sub(1, 19):lower() == "content-disposition" then
-          -- Extract part_name
           for v in line:gmatch("[^;]+") do
             if not is_header(v) then -- If it's not content disposition part
+              -- Extract part_name
               local pos = v:match("^%s*[Nn][Aa][Mm][Ee]=()")
               if pos then
                 local current_value = v:match("^%s*([^=]*)", pos):gsub("%s*$", "")
                 part_name = sub(current_value, 2, #current_value - 1)
+              end
+
+              -- Extract part_filename
+              local pos = v:match("^%s*[Ff][Ii][Ll][Ee][Nn][Aa][Mm][Ee]=()")
+              if pos then
+                local current_value = v:match("^%s*([^=]*)", pos):gsub("%s*$", "")
+                part_filename= sub(current_value, 2, #current_value - 1)
               end
             end
           end
@@ -173,12 +193,13 @@ local function decode(body, boundary)
 
   if part_name ~= nil then
     result.data[part_index] = {
-      name    = part_name,
-      headers = part_headers,
-      value   = concat(part_value)
+      name          = part_name,
+      part_filename = part_filename,
+      headers       = part_headers,
+      value         = concat(part_value)
     }
-
-    result.indexes[part_name] = part_index
+    local part_key = get_part_key(part_name, part_filename)
+    result.indexes[part_key] = part_index
   end
 
   return result
@@ -255,8 +276,9 @@ function MultipartData.new(data, content_type)
 end
 
 
-function MultipartData:get(name)
-  return self._data.data[self._data.indexes[name]]
+function MultipartData:get(name, filename)
+  local part_key = get_part_key(name, filename)
+  return self._data.data[self._data.indexes[part_key]]
 end
 
 
@@ -283,31 +305,35 @@ function MultipartData:set_simple(name, value, filename, content_type)
       headers[8] = content_type
     end
     headers = concat(headers)
-    if self._data.indexes[name] then
-      self._data.data[self._data.indexes[name]] = {
-        name = name,
-        value = value,
-        headers = {headers}
+    local part_key = get_part_key(name, filename)
+    if self._data.indexes[part_key] then
+      self._data.data[self._data.indexes[part_key]] = {
+        name        = name,
+        filename    = filename,
+        value       = value,
+        headers     = {headers}
       }
 
     else
       local part_index = table_size(self._data.indexes) + 1
-      self._data.indexes[name] = part_index
+      self._data.indexes[part_key] = part_index
       self._data.data[part_index] = {
-        name    = name,
-        value   = value,
-        headers = {headers}
+        name        = name,
+        filename    = filename,
+        value       = value,
+        headers     = {headers}
       }
     end
 end
 
 
-function MultipartData:delete(name)
-  local index = self._data.indexes[name]
+function MultipartData:delete(name, filename)
+  local part_key = get_part_key(name, filename)
+  local index = self._data.indexes[part_key]
 
   if index then
      remove(self._data.data, index)
-     self._data.indexes[name] = nil
+     self._data.indexes[part_key] = nil
 
     -- need to recount index
     for key, value in pairs(self._data.indexes) do

--- a/src/multipart.lua
+++ b/src/multipart.lua
@@ -194,7 +194,7 @@ local function decode(body, boundary)
   if part_name ~= nil then
     result.data[part_index] = {
       name          = part_name,
-      part_filename = part_filename,
+      filename      = part_filename,
       headers       = part_headers,
       value         = concat(part_value)
     }

--- a/src/multipart.lua
+++ b/src/multipart.lua
@@ -284,11 +284,27 @@ function MultipartData:get_as_array(name)
 end
 
 
-function MultipartData:get_all_with_arrays()
+function MultipartData:get_all_as_arrays()
+  -- Get all fields as arrays
   local result = {}
 
   for k, v in pairs(self._data.indexes) do
     result[k] = self:get_as_array(k)
+  end
+
+  return result
+end
+
+function MultipartData:get_all_with_arrays()
+  -- Get repeating fields as arrays, rest as strings
+  local result = {}
+
+  for k, v in pairs(self._data.indexes) do
+    if #v == 1 then
+      result[k] = self._data.data[v[1]].value
+    else
+      result[k] = self:get_as_array(k)
+    end
   end
 
   return result


### PR DESCRIPTION
Problem

It is not uncommon to attach multiple files at once to the same multipart field. In particular, we found this issue at @fundingasiagroup in one of our plugins. When multiple files are attached in request to the same part name, behavior is unstable. For example in this scenario,

- if set_simple is not used, multipart data encode and decode works correctly
- if set_simple is used, one of the files is missing after decode

This is happening because "data" structure holds all data, yet "indexes" structure overwrites indexes for files since they share part name.

Fix

If name of part repeats, append `_part_number_` with number of part to the name in "indexes" structure.

Compatibility
* When this rock is used without repeating "name" parts, all API and behavior is the same as before.
* This works if "filename" repeats or skipped.
* This works for any field, not necessary files, although files would be primary scenario according to IETF standards.

Test plan
- [x] existing tests pass
- [x] added new test case

More examples

Here is HTTP output of how Postman would encode it:

<img width="775" alt="Screenshot 2020-05-13 at 5 38 14 PM" src="https://user-images.githubusercontent.com/2933061/81796980-c1cb6780-9540-11ea-9564-68fc0ebe6217.png">

```
POST ZZZZZ
Host: FFFFF
Authorization: Bearer  XXXX
Cookie: __cfduid=YYYYYYYContent-Type: multipart/form-data; boundary=----WebKitFormBoundary7MA4YWxkTrZu0gW

----WebKitFormBoundary7MA4YWxkTrZu0gW
Content-Disposition: form-data; name="files"; filename="file2.txt"
Content-Type: text/plain

(data)
----WebKitFormBoundary7MA4YWxkTrZu0gW
Content-Disposition: form-data; name="files"; filename="file3.txt"
Content-Type: text/plain

(data)
----WebKitFormBoundary7MA4YWxkTrZu0gW
Content-Disposition: form-data; name="files"; filename="file1.txt"
Content-Type: text/plain

(data)
----WebKitFormBoundary7MA4YWxkTrZu0gW
```