### PR TITLE
replace `is_header()` check pattern

### DIFF
--- a/src/multipart.lua
+++ b/src/multipart.lua
@@ -27,7 +27,7 @@ setmetatable(MultipartData, {
 
 
 local function is_header(value)
-  return match(value, "(%S+):%s*(%S+)")
+  return match(value, "%S:%s*%S")
 end
 
 


### PR DESCRIPTION
the original pattern exhibits can take indeterminate time on long
input strings.  The semantics of:

    '(%S+):%s*(%S+)'

can be described as: "at least one non-space, followed by a colon,
optional whitespace and at least one non-space".

but the captures are not used in the code, and the match isn't
anchored at either end, so the pattern:

    '%S:%s*%S'

matches and rejects the same sets of strings and executes in
linear time.  The time to reject the text reported in #26 (200000
chars in length) drops from 150secs to 2msec.